### PR TITLE
fix: docker compose config

### DIFF
--- a/dc-mocks.yml
+++ b/dc-mocks.yml
@@ -7,7 +7,7 @@ x-healthcheck-config: &healthcheck-ref
   retries: 100
   start_period: 30s
 
-name: dc-mocks
+x-name: dc-mocks
 services:
   tiger-proxy:
     image: gematik1/tiger-proxy-image:3.3.0


### PR DESCRIPTION
use `x-name` instead of `name`

fixes:
 
```SH
docker-compose -f dc-mocks.yml up
ERROR: The Compose file './dc-mocks.yml' is invalid because:
'name' does not match any of the regexes: '^x-'

You might be seeing this error because you're using the wrong Compose file version. Either specify a supported version (e.g "2.2" or "3.3") and place your service definitions under the `services` key, or omit the `version` key and place your service definitions at the root of the file to use version 1.
For more on the Compose file format versions, see https://docs.docker.com/compose/compose-file/
```